### PR TITLE
Test against all supported versions and fix for 3.9

### DIFF
--- a/pydantic_enhanced_serializer/models.py
+++ b/pydantic_enhanced_serializer/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 from asyncio import get_event_loop, isfuture
 from typing import Any, Awaitable, Dict, List, Optional, TypedDict, Union

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Internet
 
-python_requires = >= 3.8
+python_requires = >= 3.9
 
 [options]
 packages = pydantic_enhanced_serializer, pydantic_enhanced_serializer.integrations

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+env_list = py3{9,10,11,12,13}
+
+[testenv]
+extras = test
+commands = pytest --no-cov {posargs}


### PR DESCRIPTION
`pydantic-enhanced-serializer` is currently broken on Python 3.9.

This PR:
- add a `tox.ini` config to be able to test against all supported Python versions
- raise lower Python version to 3.9 (3.8 is not supported anymore)
- fix the typing syntax issue in Python<3.10 by enabling 2 pass typing