### PR TITLE
Packaging module is required

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ python_requires = >= 3.8
 packages = pydantic_enhanced_serializer, pydantic_enhanced_serializer.integrations
 install_requires =
     pydantic >= 2.5
+    packaging >= 24.2
 
 [options.extras_require]
 test =


### PR DESCRIPTION
```
File "/opt/python/pydantic_enhanced_serializer/schema.py", line 5, in <module>
from packaging.version import Version
ModuleNotFoundError: No module named 'packaging' 
```